### PR TITLE
Deposit test

### DIFF
--- a/test/LicredityPostion.t.sol
+++ b/test/LicredityPostion.t.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Deployers} from "./utils/Deployer.sol";
+import {Fungible} from "src/types/Fungible.sol";
+import {NonFungible} from "src/types/NonFungible.sol";
+
+contract LicredityPositionTest is Deployers {
+    error NotPositionOwner();
+    error PositionNotEmpty();
+    error PositionDoesNotExist();
+    error NonZeroNativeValue();
+
+    event OpenPosition(uint256 indexed positionId, address indexed owner);
+    event ClosePosition(uint256 indexed positionId);
+    event DepositFungible(uint256 indexed positionId, Fungible indexed fungible, uint256 amount);
+
+    Fungible public fungible;
+
+    function setUp() public {
+        deployFreshETHLicredity();
+        deployNonFungibleMock();
+        deployFungibleMock();
+
+        fungible = Fungible.wrap(address(fungibleMock));
+    }
+
+    function test_openPosition() public {
+        vm.expectEmit(true, true, false, false, address(licredity));
+        emit OpenPosition(1, address(this));
+        uint256 positionId = licredity.open();
+        assertEq(positionId, 1);
+
+        positionId = licredity.open();
+        assertEq(positionId, 2);
+    }
+
+    function test_closeNullPosition() public {
+        vm.expectRevert(NotPositionOwner.selector);
+        licredity.close(0);
+    }
+
+    function test_closeOpenPosition() public {
+        licredity.open();
+        vm.expectEmit(true, false, false, false, address(licredity));
+        emit ClosePosition(1);
+        licredity.close(1);
+    }
+
+    function test_closeNotFungibleEmptyPosition() public {
+        uint256 postionId = licredity.open();
+
+        licredity.stageFungible(Fungible.wrap(address(0)));
+        licredity.depositFungible{value: 0.1 ether}(postionId);
+
+        vm.expectRevert(PositionNotEmpty.selector);
+        licredity.close(1);
+    }
+
+    function test_closeNotNonFungibleEmptyPosition() public {
+        nonFungibleMock.mint(address(this), 1);
+        NonFungible nonFungible = getMockFungible(1);
+
+        uint256 postionId = licredity.open();
+
+        licredity.stageNonFungible(nonFungible);
+        nonFungibleMock.transferFrom(address(this), address(licredity), 1);
+        licredity.depositNonFungible(postionId);
+
+        vm.expectRevert(PositionNotEmpty.selector);
+        licredity.close(1);
+    }
+
+    // TODO: close position when not zero debt share
+
+    function test_depositNullPosition() public {
+        vm.expectRevert(PositionDoesNotExist.selector);
+        licredity.depositFungible(0);
+    }
+
+    function test_depositNativeNotStage() public {
+        uint256 positionId = licredity.open();
+
+        vm.expectEmit(true, true, false, true, address(licredity));
+        emit DepositFungible(positionId, Fungible.wrap(address(0)), 0.1 ether);
+        licredity.depositFungible{value: 0.1 ether}(positionId);
+    }
+
+    // TODO: need discuss
+    function test_depositERC20NotStage() public {
+        uint256 positionId = licredity.open();
+
+        licredity.depositFungible(positionId);
+    }
+
+    function test_depositFungible() public {
+        fungibleMock.mint(address(this), 10 ether);
+        uint256 positionId = licredity.open();
+
+        licredity.stageFungible(fungible);
+        fungibleMock.transfer(address(licredity), 10 ether);
+
+        vm.expectEmit(true, true, false, true, address(licredity));
+        emit DepositFungible(positionId, fungible, 10 ether);
+        licredity.depositFungible(positionId);
+    }
+
+    function test_depositFungibleWithNative() public {
+        uint256 positionId = licredity.open();
+
+        licredity.stageFungible(fungible);
+        vm.expectRevert(NonZeroNativeValue.selector);
+        licredity.depositFungible{value: 0.1 ether}(positionId);
+    }
+}

--- a/test/libraries/Position.t.sol
+++ b/test/libraries/Position.t.sol
@@ -154,4 +154,11 @@ contract PositionTest is Test {
             }
         }
     }
+
+    function test_addRemoveDebtShare(uint256 addShare, uint256 removeShare) public {
+        vm.assume(addShare >= removeShare);
+        position.addDebtShare(addShare);
+        position.removeDebtShare(removeShare);
+        assertEq(position.debtShare, addShare - removeShare);
+    }
 }

--- a/test/mocks/NonFungibleMock.sol
+++ b/test/mocks/NonFungibleMock.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+/// @notice Modern, minimalist, and gas efficient ERC-721 implementation.
+/// @author Solmate (https://github.com/transmissions11/solmate/blob/main/src/tokens/ERC721.sol)
+contract NonFungibleMock {
+    /*//////////////////////////////////////////////////////////////
+                                 EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    event Transfer(address indexed from, address indexed to, uint256 indexed id);
+
+    event Approval(address indexed owner, address indexed spender, uint256 indexed id);
+
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    function mint(address to, uint256 id) public {
+        _mint(to, id);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                      ERC721 BALANCE/OWNER STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    mapping(uint256 => address) internal _ownerOf;
+
+    mapping(address => uint256) internal _balanceOf;
+
+    function ownerOf(uint256 id) public view virtual returns (address owner) {
+        require((owner = _ownerOf[id]) != address(0), "NOT_MINTED");
+    }
+
+    function balanceOf(address owner) public view virtual returns (uint256) {
+        require(owner != address(0), "ZERO_ADDRESS");
+
+        return _balanceOf[owner];
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         ERC721 APPROVAL STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    mapping(uint256 => address) public getApproved;
+
+    mapping(address => mapping(address => bool)) public isApprovedForAll;
+
+    /*//////////////////////////////////////////////////////////////
+                              ERC721 LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function approve(address spender, uint256 id) public virtual {
+        address owner = _ownerOf[id];
+
+        require(msg.sender == owner || isApprovedForAll[owner][msg.sender], "NOT_AUTHORIZED");
+
+        getApproved[id] = spender;
+
+        emit Approval(owner, spender, id);
+    }
+
+    function setApprovalForAll(address operator, bool approved) public virtual {
+        isApprovedForAll[msg.sender][operator] = approved;
+
+        emit ApprovalForAll(msg.sender, operator, approved);
+    }
+
+    function transferFrom(address from, address to, uint256 id) public virtual {
+        require(from == _ownerOf[id], "WRONG_FROM");
+
+        require(to != address(0), "INVALID_RECIPIENT");
+
+        require(
+            msg.sender == from || isApprovedForAll[from][msg.sender] || msg.sender == getApproved[id], "NOT_AUTHORIZED"
+        );
+
+        // Underflow of the sender's balance is impossible because we check for
+        // ownership above and the recipient's balance can't realistically overflow.
+        unchecked {
+            _balanceOf[from]--;
+
+            _balanceOf[to]++;
+        }
+
+        _ownerOf[id] = to;
+
+        delete getApproved[id];
+
+        emit Transfer(from, to, id);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 id) public virtual {
+        transferFrom(from, to, id);
+
+        require(
+            to.code.length == 0
+                || ERC721TokenReceiver(to).onERC721Received(msg.sender, from, id, "")
+                    == ERC721TokenReceiver.onERC721Received.selector,
+            "UNSAFE_RECIPIENT"
+        );
+    }
+
+    function safeTransferFrom(address from, address to, uint256 id, bytes calldata data) public virtual {
+        transferFrom(from, to, id);
+
+        require(
+            to.code.length == 0
+                || ERC721TokenReceiver(to).onERC721Received(msg.sender, from, id, data)
+                    == ERC721TokenReceiver.onERC721Received.selector,
+            "UNSAFE_RECIPIENT"
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                              ERC165 LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        return interfaceId == 0x01ffc9a7 // ERC165 Interface ID for ERC165
+            || interfaceId == 0x80ac58cd // ERC165 Interface ID for ERC721
+            || interfaceId == 0x5b5e139f; // ERC165 Interface ID for ERC721Metadata
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        INTERNAL MINT/BURN LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function _mint(address to, uint256 id) internal virtual {
+        require(to != address(0), "INVALID_RECIPIENT");
+
+        require(_ownerOf[id] == address(0), "ALREADY_MINTED");
+
+        // Counter overflow is incredibly unrealistic.
+        unchecked {
+            _balanceOf[to]++;
+        }
+
+        _ownerOf[id] = to;
+
+        emit Transfer(address(0), to, id);
+    }
+
+    function _burn(uint256 id) internal virtual {
+        address owner = _ownerOf[id];
+
+        require(owner != address(0), "NOT_MINTED");
+
+        // Ownership check above ensures no underflow.
+        unchecked {
+            _balanceOf[owner]--;
+        }
+
+        delete _ownerOf[id];
+
+        delete getApproved[id];
+
+        emit Transfer(owner, address(0), id);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        INTERNAL SAFE MINT LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function _safeMint(address to, uint256 id) internal virtual {
+        _mint(to, id);
+
+        require(
+            to.code.length == 0
+                || ERC721TokenReceiver(to).onERC721Received(msg.sender, address(0), id, "")
+                    == ERC721TokenReceiver.onERC721Received.selector,
+            "UNSAFE_RECIPIENT"
+        );
+    }
+
+    function _safeMint(address to, uint256 id, bytes memory data) internal virtual {
+        _mint(to, id);
+
+        require(
+            to.code.length == 0
+                || ERC721TokenReceiver(to).onERC721Received(msg.sender, address(0), id, data)
+                    == ERC721TokenReceiver.onERC721Received.selector,
+            "UNSAFE_RECIPIENT"
+        );
+    }
+}
+
+/// @notice A generic interface for a contract which properly accepts ERC721 tokens.
+/// @author Solmate (https://github.com/transmissions11/solmate/blob/main/src/tokens/ERC721.sol)
+abstract contract ERC721TokenReceiver {
+    function onERC721Received(address, address, uint256, bytes calldata) external virtual returns (bytes4) {
+        return ERC721TokenReceiver.onERC721Received.selector;
+    }
+}

--- a/test/utils/Deployer.sol
+++ b/test/utils/Deployer.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Test} from "@forge-std/Test.sol";
+import {Licredity} from "src/Licredity.sol";
+import {NonFungible} from "src/types/NonFungible.sol";
+import {NonFungibleMock} from "test/mocks/NonFungibleMock.sol";
+import {TestERC20} from "@uniswap-v4-core/test/TestERC20.sol";
+
+contract Deployers is Test {
+    address constant UNISWAP_V4 = address(0x000000000004444c5dc75cB358380D2e3dE08A90);
+    Licredity public licredity;
+    NonFungibleMock public nonFungibleMock;
+    TestERC20 public fungibleMock;
+
+    function deployFreshETHLicredity() public {
+        licredity = new Licredity(address(0), UNISWAP_V4, "Debt ETH", "DETH", 18);
+    }
+
+    function deployNonFungibleMock() public {
+        nonFungibleMock = new NonFungibleMock();
+    }
+
+    function deployFungibleMock() public {
+        fungibleMock = new TestERC20(0);
+    }
+
+    function getMockFungible(uint256 tokenId) public view returns (NonFungible nft) {
+        address nonFungibleMockAddress = address(nonFungibleMock);
+        assembly ("memory-safe") {
+            nft := or(shl(96, nonFungibleMockAddress), tokenId)
+        }
+    }
+}


### PR DESCRIPTION
Added tests for `open` / `close` / `depositFungible` / `depositNonFungible` functions in Licredity and found the following special cases:

```solidity
function test_depositNullPosition() public {
    vm.expectRevert(PositionDoesNotExist.selector);
    licredity.depositFungible(0);
}
```